### PR TITLE
Omega: add ability to apply filter and shuffle to frozen items

### DIFF
--- a/Wanikani/README.md
+++ b/Wanikani/README.md
@@ -1,1 +1,4 @@
 Minor features
+
+### Build Note
+`cd` into the Reorder Omega directory first if not already there and run `npx tsc reorder.user.ts` to generate/overwrite the `user.js` file.

--- a/Wanikani/Reorder Omega/reorder.d.ts
+++ b/Wanikani/Reorder Omega/reorder.d.ts
@@ -138,12 +138,14 @@ export namespace Settings {
             values: {
                 [key: string]: any
                 invert: boolean
+                apply_to_frozen: boolean
             }
         }
         shuffle: {
             type: 'random' | 'relative'
             values: {
                 relative: number
+                apply_to_frozen: boolean
             }
         }
     }

--- a/Wanikani/Reorder Omega/reorder.user.js
+++ b/Wanikani/Reorder Omega/reorder.user.js
@@ -2,12 +2,12 @@
 // ==UserScript==
 // @name         Wanikani: Reorder Omega
 // @namespace    http://tampermonkey.net/
-// @version      1.3.52
+// @version      1.3.53
 // @description  Reorders n stuff
 // @author       Kumirei
 // @match        https://www.wanikani.com/*
 // @match        https://preview.wanikani.com/*
-// @require      https://greasyfork.org/scripts/489759-wk-custom-icons/code/CustomIcons.js?version=1350892
+// @require      https://greasyfork.org/scripts/489759-wk-custom-icons/code/CustomIcons.js?version=1386034
 // @require      https://greasyfork.org/scripts/462049-wanikani-queue-manipulator/code/WaniKani%20Queue%20Manipulator.user.js?version=1340063
 // @grant        none
 // @run-at       document-idle
@@ -314,18 +314,21 @@ var module = {};
     }
     // Performs the actions on the items
     function process_action(action, items) {
+        var unfreezing = false;
         switch (action.type) {
             case 'none':
                 return items;
             case 'filter':
-                var _a = process_filter(action, items.keep), keep = _a.keep, discard = _a.discard;
-                return { keep: keep, discard: items.discard.concat(discard), final: items.final };
+                unfreezing = action.filter.values.apply_to_frozen;
+                var _a = process_filter(action, unfreezing ? items.keep.concat(items.final) : items.keep), keep = _a.keep, discard = _a.discard;
+                return { keep: keep, discard: items.discard.concat(discard), final: unfreezing ? [] : items.final };
             case 'sort':
                 return { keep: process_sort_action(action, items.keep), discard: items.discard, final: items.final };
             case 'freeze & restore':
                 return { keep: items.discard, discard: [], final: items.final.concat(items.keep) };
             case 'shuffle':
-                return { keep: process_shuffle_action(action, items.keep), discard: items.discard, final: items.final };
+                unfreezing = action.shuffle.values.apply_to_frozen;
+                return { keep: process_shuffle_action(action, unfreezing ? items.keep.concat(items.final) : items.keep), discard: items.discard, final: unfreezing ? [] : items.final };
             default:
                 // ? Maybe return nothing and display a message?
                 return items; // Invalid action type
@@ -1162,8 +1165,10 @@ var module = {};
         // Set some classes
         dialog.find('[name="filter_type"]').closest('.row').addClass('filter');
         dialog.find('[name="filter_invert"]').closest('.row').addClass('filter');
+        dialog.find('[name="filter_frozen"]').closest('.row').addClass('filter');
         dialog.find('[name="sort_type"]').closest('.row').addClass('sort');
         dialog.find('[name="shuffle_type"]').closest('.row').addClass('shuffle');
+        dialog.find('[name="shuffle_frozen"]').closest('.row').addClass('shuffle');
         // Add pasting inputs
         dialog
             .find("fieldset#".concat(script_id, "_presets"))
@@ -1382,7 +1387,8 @@ var module = {};
             filter: {
                 type: 'level',
                 values: {
-                    invert: false
+                    invert: false,
+                    apply_to_frozen: false
                 }
             },
             sort: {
@@ -1394,7 +1400,8 @@ var module = {};
             shuffle: {
                 type: 'random',
                 values: {
-                    relative: 10
+                    relative: 10,
+                    apply_to_frozen: false
                 }
             }
         }; // Casting because it is still incomplete
@@ -1475,6 +1482,13 @@ var module = {};
             hover_tip: 'Check this box if you want to invert the effect of this filter.',
             path: '@presets[@selected_preset].actions[@presets[@selected_preset].selected_action].filter.values.invert'
         };
+        config.content.filter_frozen = {
+            type: 'checkbox',
+            "default": false,
+            label: 'Also apply to frozen items',
+            hover_tip: 'Check this box if you want to apply this filter to all items that have been frozen by Freeze & Restore actions.',
+            path: '@presets[@selected_preset].actions[@presets[@selected_preset].selected_action].filter.values.apply_to_frozen'
+        };
         // Populate sort values
         var numerical_sort_config = function (type) {
             return ({
@@ -1508,6 +1522,13 @@ var module = {};
             label: 'Shuffle Distance (%)',
             hover_tip: 'The distance you want any given item to be able to move relative to its start position. Percentage of total number of items.',
             path: "@presets[@selected_preset].actions[@presets[@selected_preset].selected_action].shuffle.values.relative"
+        };
+        config.content.shuffle_frozen = {
+            type: 'checkbox',
+            "default": false,
+            label: 'Also apply to frozen items',
+            hover_tip: 'Check this box if you want to also shuffle all items that have been frozen by Freeze & Restore actions.',
+            path: '@presets[@selected_preset].actions[@presets[@selected_preset].selected_action].shuffle.values.apply_to_frozen'
         };
     }
     // -----------------------------------------------------------------------------------------------------------------

--- a/Wanikani/WKOF Types/wkof.d.ts
+++ b/Wanikani/WKOF Types/wkof.d.ts
@@ -414,11 +414,12 @@ declare namespace ItemData {
                             type: 'multi'
                             default: []
                             label: 'Item type'
-                            hover_tip: 'Filter by item type (radical, kanji, vocabulary)'
+                            hover_tip: 'Filter by item type (radical, kanji, vocabulary, kana_vocabulary)'
                             content: {
                                 radical: 'Radicals'
                                 kanji: 'Kanji'
                                 vocabulary: 'Vocabulary'
+                                kana_vocabulary: 'Kana Vocabulary'
                             }
                             filter_value_map: (filter_value: SubjectTypeShort[] | SubjectTypeShortString) => {
                                 [key: string]: boolean

--- a/Wanikani/WKOF Types/wkof.d.ts
+++ b/Wanikani/WKOF Types/wkof.d.ts
@@ -5,11 +5,13 @@ type SubjectTypeString =
     | `${SubjectType}`
     | `${SubjectType},${SubjectType}`
     | `${SubjectType},${SubjectType},${SubjectType}`
-type SubjectTypeShort = 'voc' | 'kan' | 'rad'
+    | `${SubjectType},${SubjectType},${SubjectType},${SubjectType}`
+type SubjectTypeShort = 'voc' | 'kan' | 'rad' | 'kana_voc'
 type SubjectTypeShortString =
     | `${SubjectTypeShort}`
     | `${SubjectTypeShort},${SubjectTypeShort}`
     | `${SubjectTypeShort},${SubjectTypeShort},${SubjectTypeShort}`
+    | `${SubjectTypeShort},${SubjectTypeShort},${SubjectTypeShort},${SubjectTypeShort}`
 type IsoDateString = `${number}-${number}-${number}T${number}:${number}:${number}.${number}Z`
 
 declare namespace Core {


### PR DESCRIPTION
Adds a checkbox option when the filter or shuffle actions are chosen. It only applies to filter and shuffle currently since applying a sort to frozen items would undo previous sorts, but I might still add this later since if the user hasn't done any sorts before it then it would be ok.

The readme change is just because when I come back to this repo after a long time I genuinely forget how to compile the typescript, so a small note to an otherwise not-used file should be fine.