### PR TITLE
Fix Porter script for the recent WaniKani changes

### DIFF
--- a/Wanikani/WKOF Settings Im- & Exporter/porter.user.js
+++ b/Wanikani/WKOF Settings Im- & Exporter/porter.user.js
@@ -2,10 +2,11 @@
 // ==UserScript==
 // @name         Wanikani: Settings Exporter & Importer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.3
+// @version      1.1.4
 // @description  Imports and exports your WKOF settings
 // @author       Kumirei
-// @include      /^https://(www|preview).wanikani.com/(dashboard)?/
+// @match        https://www.wanikani.com/*
+// @match        https://preview.wanikani.com/*
 // @grant        none
 // @license      MIT
 // ==/UserScript==
@@ -50,6 +51,15 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var module = {};
 ;
 (function () { return __awaiter(void 0, void 0, void 0, function () {
+    function init() {
+        return __awaiter(this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                wkof.include('Menu,Settings,Jquery');
+                wkof.ready('Jquery,Menu,Settings').then(install_menu).then(install_css);
+                return [2 /*return*/];
+            });
+        });
+    }
     // Makes sure that WKOF is installed
     function confirm_wkof() {
         return __awaiter(this, void 0, void 0, function () {
@@ -104,15 +114,15 @@ var module = {};
                             html: "<div class=\"row full\">" +
                                 "   <div class=\"left\"><label>Settings string</label></div>" +
                                 "   <div class=\"right\">" +
-                                "       <textarea disabled id=\"exported_script_settings\" placeholder=\"Your exported settings will appear here\"/>" +
+                                "       <textarea disabled id=\"exported_script_settings\" placeholder=\"Your exported settings will appear here\"></textarea>" +
                                 "   </div>" +
                                 "</div>"
                         },
                         buttons: {
                             type: 'html',
                             html: "<div class=\"porter_buttons\">" +
-                                "<button type=\"button\" action=\"copy\" class=\"ui-button ui-corner-all ui-widget\" title=\"Copy the settings string to your clipboard\">COPY</button>" +
-                                "<button type=\"button\" action=\"save\" class=\"ui-button ui-corner-all ui-widget\" title=\"Save the settings to a file\">SAVE</button>" +
+                                "    <button type=\"button\" action=\"copy\" class=\"ui-button ui-corner-all ui-widget\" title=\"Copy the settings string to your clipboard\">COPY</button>" +
+                                "    <button type=\"button\" action=\"save\" class=\"ui-button ui-corner-all ui-widget\" title=\"Save the settings to a file\">SAVE</button>" +
                                 "</div>"
                         }
                     }
@@ -126,7 +136,7 @@ var module = {};
                             html: "<div class=\"row full\">" +
                                 "   <div class=\"left\"><label>Settings string</label></div>" +
                                 "   <div class=\"right\">" +
-                                "       <textarea id=\"import_script_settings\" placeholder=\"Paste your exported settings here or load settings from a file below\"/>" +
+                                "       <textarea id=\"import_script_settings\" placeholder=\"Paste your exported settings here or load settings from a file below\"></textarea>" +
                                 "   </div>" +
                                 "</div>"
                         },
@@ -334,8 +344,10 @@ var module = {};
                 wkof = window.wkof;
                 // Init
                 confirm_wkof();
-                wkof.include('Menu,Settings,Jquery');
-                wkof.ready('Menu,Settings').then(install_menu).then(install_css);
+                window.addEventListener('turbo:load', function () {
+                    setTimeout(init, 0);
+                });
+                wkof.include('Jquery');
                 return [4 /*yield*/, wkof.ready('Jquery')];
             case 1:
                 _a.sent();

--- a/Wanikani/WKOF Settings Im- & Exporter/porter.user.ts
+++ b/Wanikani/WKOF Settings Im- & Exporter/porter.user.ts
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         Wanikani: Settings Exporter & Importer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.3
+// @version      1.1.4
 // @description  Imports and exports your WKOF settings
 // @author       Kumirei
-// @include      /^https://(www|preview).wanikani.com/(dashboard)?/
+// @match        https://www.wanikani.com/*
+// @match        https://preview.wanikani.com/*
 // @grant        none
 // @license      MIT
 // ==/UserScript==
@@ -39,8 +40,17 @@ declare global {
 
     // Init
     confirm_wkof()
-    wkof.include('Menu,Settings,Jquery')
-    wkof.ready('Menu,Settings').then(install_menu).then(install_css)
+
+    window.addEventListener('turbo:load', () => {
+        setTimeout(init, 0)
+    })
+
+    async function init(): Promise<void> {
+        wkof.include('Menu,Settings,Jquery')
+        wkof.ready('Jquery,Menu,Settings').then(install_menu).then(install_css)
+    }
+
+    wkof.include('Jquery')
     await wkof.ready('Jquery')
 
     const porter = {
@@ -106,7 +116,7 @@ declare global {
                                 `<div class="row full">` +
                                 `   <div class="left"><label>Settings string</label></div>` +
                                 `   <div class="right">` +
-                                `       <textarea disabled id="exported_script_settings" placeholder="Your exported settings will appear here"/>` +
+                                `       <textarea disabled id="exported_script_settings" placeholder="Your exported settings will appear here"></textarea>` +
                                 `   </div>` +
                                 `</div>`,
                         },
@@ -114,8 +124,8 @@ declare global {
                             type: 'html',
                             html:
                                 `<div class="porter_buttons">` +
-                                `<button type="button" action="copy" class="ui-button ui-corner-all ui-widget" title="Copy the settings string to your clipboard">COPY</button>` +
-                                `<button type="button" action="save" class="ui-button ui-corner-all ui-widget" title="Save the settings to a file">SAVE</button>` +
+                                `    <button type="button" action="copy" class="ui-button ui-corner-all ui-widget" title="Copy the settings string to your clipboard">COPY</button>` +
+                                `    <button type="button" action="save" class="ui-button ui-corner-all ui-widget" title="Save the settings to a file">SAVE</button>` +
                                 `</div>`,
                         },
                     },
@@ -130,7 +140,7 @@ declare global {
                                 `<div class="row full">` +
                                 `   <div class="left"><label>Settings string</label></div>` +
                                 `   <div class="right">` +
-                                `       <textarea id="import_script_settings" placeholder="Paste your exported settings here or load settings from a file below"/>` +
+                                `       <textarea id="import_script_settings" placeholder="Paste your exported settings here or load settings from a file below"></textarea>` +
                                 `   </div>` +
                                 `</div>`,
                         },


### PR DESCRIPTION
The recent removal of jQuery and the completed move to Turbo broke this script. The jQuery wasn't much of an issue because we are using Open Framework to fill that in, but the move to Turbo did break it working when navigating back to the dashboard. There's been discussion in the forums about how best to handle the turbo events and it was discovered that listening to "turbo:load" and using a setTimeout with no ms to delay to the next tick of the event loop is able to handle the vast majority of cases. It works perfectly fine here too.

Until Open Framework itself has fixed its support of turbo navigation, we need to wrap the calls to `include` and `ready` in a function and call that function on "turbo:load" to reinitialize open framework. Once Open Framework supports this natively this can likely be reverted.