### PR TITLE
Skip logging error for status code 304

### DIFF
--- a/Wanikani/Review Cache/review_cache.js
+++ b/Wanikani/Review Cache/review_cache.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Wanikani: Review Cache
-// @version      1.2.9
+// @version      1.2.10
 // @description  Manages a cache of all the user's reviews
 // @author       Kumirei
 // @include      *wanikani.com*
@@ -12,7 +12,7 @@
     const cache_version = 1
 
     // Script version. Starts with q to make it larger than numerical versions
-    const version = 'q1.2.9'
+    const version = 'q1.2.10'
 
     // Update interval for subscriptions
     const update_interval = 10 // minutes
@@ -180,7 +180,8 @@
     }
 
     function fetch_error(error) {
-        console.warn('Review Cache: Error fetching reviews', error)
+        if (error.status !== 304) // skip logging for 304 Not Modified
+            console.warn('Review Cache: Error fetching reviews', error)
         return { error }
     }
 })(window.wkof)


### PR DESCRIPTION
As far as I am aware, there's no need to log an error on status code 304, since it's indicating that nothing has changed.