### PR TITLE
Fix Review Queue Sizer (out of date dependency)

### DIFF
--- a/Wanikani/Review Queue Sizer/userscript.js
+++ b/Wanikani/Review Queue Sizer/userscript.js
@@ -6,7 +6,7 @@
 // @author       Kumirei
 // @match        https://www.wanikani.com/*
 // @match        https://preview.wanikani.com/*
-// @require      https://greasyfork.org/scripts/462049-wanikani-queue-manipulator/code/WaniKani%20Queue%20Manipulator.user.js?version=1340063
+// @require      https://greasyfork.org/scripts/462049-wanikani-queue-manipulator/code/WaniKani%20Queue%20Manipulator.user.js
 // @grant        none
 // ==/UserScript==
 


### PR DESCRIPTION
Wanikani moved to a JSON representation of the Queue at some point over the summer, breaking the Review Queue Sizer much to my dismay.

Turns out the underlying library for manipulation fixed this issue in v17 (https://community.wanikani.com/t/for-userscript-authors-wk-queue-manipulator/61302) but the library version was pinned in the require here.

Removing the version pin, which will make it default to latest, meaning future fixes from Review Queue Manipulator will come "for free."

Alternately, we could pin to the explicit latest version (version=1448112), but given the fact that this userscript has been broken for at least two months, I think pinning to latest is the lesser evil.